### PR TITLE
Add configuration file

### DIFF
--- a/amdgpu-fancontrol
+++ b/amdgpu-fancontrol
@@ -14,6 +14,16 @@ FILE_TEMP=/sys/class/drm/card0/device/hwmon/hwmon0/temp1_input
 # might want to use this later
 #FILE_TEMP_CRIT=/sys/class/hwmon/hwmon0/temp1_crit_hyst
 
+# load configuration file if present
+[ -f /etc/amdgpu-fancontrol.cfg ] && . /etc/amdgpu-fancontrol.cfg
+
+# check if amount of temps and pwm values match
+if [ "${#TEMPS[@]}" -ne "${#PWMS[@]}" ]
+then
+  echo "Amount of temperature and pwm values does not match"
+  exit 1
+fi
+
 # checking for privileges
 if [ $UID -ne 0 ]
 then

--- a/etc-amdgpu-fancontrol.cfg
+++ b/etc-amdgpu-fancontrol.cfg
@@ -1,0 +1,17 @@
+# Configuration file for amdgpu fancontol service
+
+# Set temperature and corresponding pwm values in ascending order and with the
+# same amount of values. A linear interpolation will happen for values in
+# between.
+
+# Temperatures in degrees C * 1000
+# Default: ( 65000 80000 90000 )
+#
+#TEMPS=( 65000 80000 90000 )
+
+# PWM values corresponding to the defined temperatures.
+# 0 will turn the fans off.
+# 255 will let them spin at maximum speed.
+# Default: ( 0 153 255 )
+#
+#PWMS=( 0 153 255 )


### PR DESCRIPTION
This patch adds a simple configuration file which lets you define the
temperature and pwm values in `/etc/amdgpu-fancontrol.cfg` instead of
editing the script itself.

It also introduces a simple test for the amount of temp and pwm values,
aborting with an error if the amount differs.