### PR TITLE
Make sure fanmode is set to manual before setting a pwm

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ license=('GPL')
 depends=('systemd' 'bc')
 
 source=('amdgpu-fancontrol' 'amdgpu-fancontrol.service')
-sha256sums=('7e1c4af47bdbab1bc4a239b22e1b6f10dc2338de500705eb5edae5bfe8ceedfe'
+sha256sums=('da54bd9c985602ab556bdf6f33ab84a3f1dc5b694508e208efba7c1996553122'
             '509d5c2676ea0aa23918bebd1b4f5f0268b0a6a68a27650ce487dfb58f27e70c')
 
 package() {

--- a/amdgpu-fancontrol
+++ b/amdgpu-fancontrol
@@ -42,6 +42,11 @@ function set_pwm {
   OLD_PWM=$(cat $FILE_PWM)
 
   echo "current pwm: $OLD_PWM, requested to set pwm to $NEW_PWM"
+  if [ $(cat ${FILE_FANMODE}) -ne 1 ]
+  then
+    echo "Fanmode not set to manual."
+    set_fanmode 1
+  fi
 
   if [ "$NEW_PWM" -gt "$OLD_PWM" ] || [ -z "$TEMP_AT_LAST_PWM_CHANGE" ] || [ $(($(cat $FILE_TEMP) + HYSTERESIS)) -le "$TEMP_AT_LAST_PWM_CHANGE" ]; then
     echo "temp at last change was $TEMP_AT_LAST_PWM_CHANGE"


### PR DESCRIPTION
When leaving suspended state the driver may reset the fanmode to automatic. This makes sure it's set to manual before setting pwm.