### PR TITLE
Add Debug Mode

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,9 +9,9 @@ license=('GPL')
 depends=('systemd' 'bc')
 
 source=('amdgpu-fancontrol' 'amdgpu-fancontrol.service' 'etc-amdgpu-fancontrol.cfg')
-sha256sums=('da54bd9c985602ab556bdf6f33ab84a3f1dc5b694508e208efba7c1996553122'
+sha256sums=('9f0a3d7ae3c7c1807de5f954d05a6883e4196b535e846737af300935fcf45110'
             '509d5c2676ea0aa23918bebd1b4f5f0268b0a6a68a27650ce487dfb58f27e70c'
-            '9531b0dc6e8497ba8b40d9b3a7a5d6af80c6b804200e7a291b251153ff92e262')
+            '0a032a9fe2c1c6f985e898eb84b5ae658e08146038f44f7ed4a09400e7f06d39')
 
 package() {
     mkdir -p ${pkgdir}/usr/bin

--- a/amdgpu-fancontrol
+++ b/amdgpu-fancontrol
@@ -2,6 +2,7 @@
 
 HYSTERESIS=6000   # in mK
 SLEEP_INTERVAL=1  # in s
+DEBUG=true
 
 # set temps (in degrees C * 1000) and corresponding pwm values in ascending order and with the same amount of values
 TEMPS=( 65000 80000 90000 )
@@ -31,6 +32,12 @@ then
   exit 1
 fi
 
+function debug {
+  if $DEBUG; then
+    echo $1
+  fi
+}
+
 # set fan mode to max(0), manual(1) or auto(2)
 function set_fanmode {
   echo "setting fan mode to $1"
@@ -42,6 +49,7 @@ function set_pwm {
   OLD_PWM=$(cat $FILE_PWM)
 
   echo "current pwm: $OLD_PWM, requested to set pwm to $NEW_PWM"
+  debug "current pwm: $OLD_PWM, requested to set pwm to $NEW_PWM"
   if [ $(cat ${FILE_FANMODE}) -ne 1 ]
   then
     echo "Fanmode not set to manual."
@@ -49,12 +57,13 @@ function set_pwm {
   fi
 
   if [ "$NEW_PWM" -gt "$OLD_PWM" ] || [ -z "$TEMP_AT_LAST_PWM_CHANGE" ] || [ $(($(cat $FILE_TEMP) + HYSTERESIS)) -le "$TEMP_AT_LAST_PWM_CHANGE" ]; then
+    $DEBUG || echo "current temp: $TEMP"
     echo "temp at last change was $TEMP_AT_LAST_PWM_CHANGE"
     echo "changing pwm to $NEW_PWM"
     echo "$NEW_PWM" > "$FILE_PWM"
     TEMP_AT_LAST_PWM_CHANGE=$(cat $FILE_TEMP)
   else
-    echo "not changing pwm, we just did at $TEMP_AT_LAST_PWM_CHANGE, next change when below $((TEMP_AT_LAST_PWM_CHANGE - HYSTERESIS))"
+    debug "not changing pwm, we just did at $TEMP_AT_LAST_PWM_CHANGE, next change when below $((TEMP_AT_LAST_PWM_CHANGE - HYSTERESIS))"
   fi
 }
 
@@ -62,7 +71,7 @@ function interpolate_pwm {
   i=0
   TEMP=$(cat $FILE_TEMP)
 
-  echo "current temp: $TEMP"
+  debug "current temp: $TEMP"
 
   if [[ $TEMP -le ${TEMPS[0]} ]]; then
     # below first point in list, set to min speed
@@ -85,7 +94,7 @@ function interpolate_pwm {
     LOWERPWM=${PWMS[i-1]}
     HIGHERPWM=${PWMS[i]}
     PWM=$(echo "( ( $TEMP - $LOWERTEMP ) * ( $HIGHERPWM - $LOWERPWM ) / ( $HIGHERTEMP - $LOWERTEMP ) ) + $LOWERPWM" | bc)
-    echo "interpolated pwm value for temperature $TEMP is: $PWM"
+    debug "interpolated pwm value for temperature $TEMP is: $PWM"
     set_pwm "$PWM"
     return
   done
@@ -103,7 +112,7 @@ trap "reset_on_fail" SIGINT SIGTERM
 function run_daemon {
   while :; do
     interpolate_pwm
-    echo
+    debug
     sleep $SLEEP_INTERVAL
   done
 }

--- a/etc-amdgpu-fancontrol.cfg
+++ b/etc-amdgpu-fancontrol.cfg
@@ -15,3 +15,8 @@
 # Default: ( 0 153 255 )
 #
 #PWMS=( 0 153 255 )
+
+# Debug mode.
+# Enabling this will make amdgpu fancontol much more verbose.
+# Default: true
+#DEBUG=true


### PR DESCRIPTION
This patch adds a debug option to amdgpu fancontrol which controls how
many log messages are written.

In debug mode – enabled by default – the toll will act exactly like
before. However, I found this to kind of spam the system log, so when
disabled, only actual PWM changes will be logged, making the tool much
more quiet.