### PR TITLE
Change service start order to fix service start error

### DIFF
--- a/amdgpu-fancontrol.service
+++ b/amdgpu-fancontrol.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=amdgpu-fancontrol
+After=multi-user.target rc-local.service systemd-user-sessions.service
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/amdgpu-fancontrol
+StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Service currently fails to start.

This changes the order so:

```
amdgpu-fancontrol[484]: invalid hwmon files
```

Will be avoided. More details also in #25  