### PR TITLE
Fix not being able to start service because temperature not yet available

### DIFF
--- a/amdgpu-fancontrol.service
+++ b/amdgpu-fancontrol.service
@@ -3,6 +3,7 @@ Description=amdgpu-fancontrol
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sleep 5
 ExecStart=/usr/bin/amdgpu-fancontrol
 
 [Install]

--- a/amdgpu-fancontrol.service
+++ b/amdgpu-fancontrol.service
@@ -2,9 +2,9 @@
 Description=amdgpu-fancontrol
 
 [Service]
-Type=simple
-ExecStartPre=/bin/sleep 5
 ExecStart=/usr/bin/amdgpu-fancontrol
+Restart=on-failure
+RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
sometimes it takes a while for the temperature of the gpu to become available, leading to
```
FILE_TEMP=$(echo /sys/class/drm/card0/device/hwmon/hwmon?/temp1_input)
```
being empty and the service failing with "invalid hwmon files".

I tried to look for a valid service to start after, but it doesn't seem to exist. Alternative to this solution there's a few others:

- Restart (with 5 sec delays) until service starts successfully.
- Add a path watcher for `/sys/class/drm/card0/device/hwmon/hwmon?/temp1_input`

The first could lead to an infinite restart loop, the second muddles logic from the `amdgpu_control` script and the service.

Open to suggestions. The fix suggested in #25 is not sufficient for me, but this works.

 fixes #25