### PR TITLE
fix startup issues at boot

### DIFF
--- a/amdgpu-fancontrol.path
+++ b/amdgpu-fancontrol.path
@@ -1,0 +1,7 @@
+[Path]
+PathExistsGlob=/sys/class/drm/card0/device/hwmon/hwmon*/pwm1
+PathExistsGlob=/sys/class/drm/card0/device/hwmon/hwmon*/pwm1_enable
+PathExistsGlob=/sys/class/drm/card0/device/hwmon/hwmon*/temp1_input
+
+[Install]
+WantedBy=default.target

--- a/amdgpu-fancontrol.service
+++ b/amdgpu-fancontrol.service
@@ -1,6 +1,3 @@
-[Unit]
-Description=amdgpu-fancontrol
-
 [Service]
 Type=simple
 ExecStart=/usr/bin/amdgpu-fancontrol

--- a/amdgpu-fancontrol.service
+++ b/amdgpu-fancontrol.service
@@ -4,6 +4,3 @@ Description=amdgpu-fancontrol
 [Service]
 Type=simple
 ExecStart=/usr/bin/amdgpu-fancontrol
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
fixes #25 

Instead of enabling the service directly, `amdgpu-fancontrol.path` is what needs to be enabled/started now. 

While working on this i noticed that Linux 5.11 seems to properly apply the fan curve from my GPU bios now which means i won’t need this service anymore. Mentioning that for people who used it for the same reason i did. Of course it’s still useful for custom fan curves. 